### PR TITLE
Use XDG_CACHE_HOME on Linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,6 @@ setuptools.setup(
     python_requires = '>=3.8',
     install_requires = [
         'pygame',
+        'pyxdg',
     ],
 )


### PR DESCRIPTION
This PR allows `ialauncher` to be installed in system directories on Linux by using the user's cache directory to download and launch games.  Behavior on Windows and macOS have not been tested, but should remain unchanged.

See https://github.com/rtts/ialauncher/issues/11